### PR TITLE
feat: draft k8s deployment config

### DIFF
--- a/app-emissary/deployment.yaml
+++ b/app-emissary/deployment.yaml
@@ -32,6 +32,51 @@ spec:
               "-config",
               "api.key=${ZAP_API_KEY}",
             ]
-          ports:
-            - containerPort: 80
 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zap-service
+  labels:
+    container: app-emissary
+spec:
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 8080
+    - name: "8081"
+      port: 8081
+      targetPort: 8080
+    - name: "8082"
+      port: 8082
+      targetPort: 8080
+    - name: "8083"
+      port: 8083
+      targetPort: 8080
+    - name: "8084"
+      port: 8084
+      targetPort: 8080
+    - name: "8085"
+      port: 8085
+      targetPort: 8080
+    - name: "8086"
+      port: 8086
+      targetPort: 8080
+    - name: "8087"
+      port: 8087
+      targetPort: 8080
+    - name: "8088"
+      port: 8088
+      targetPort: 8080
+    - name: "8089"
+      port: 8089
+      targetPort: 8080
+    - name: "8090"
+      port: 8090
+      targetPort: 8080
+    - name: "8091"
+      port: 8091
+      targetPort: 8080
+  selector:
+    container: app-emissary

--- a/app-emissary/deployment.yaml
+++ b/app-emissary/deployment.yaml
@@ -41,42 +41,11 @@ metadata:
   labels:
     container: app-emissary
 spec:
+  type: NodePort
   ports:
     - name: "8080"
+      nodePort: 30000
       port: 8080
-      targetPort: 8080
-    - name: "8081"
-      port: 8081
-      targetPort: 8080
-    - name: "8082"
-      port: 8082
-      targetPort: 8080
-    - name: "8083"
-      port: 8083
-      targetPort: 8080
-    - name: "8084"
-      port: 8084
-      targetPort: 8080
-    - name: "8085"
-      port: 8085
-      targetPort: 8080
-    - name: "8086"
-      port: 8086
-      targetPort: 8080
-    - name: "8087"
-      port: 8087
-      targetPort: 8080
-    - name: "8088"
-      port: 8088
-      targetPort: 8080
-    - name: "8089"
-      port: 8089
-      targetPort: 8080
-    - name: "8090"
-      port: 8090
-      targetPort: 8080
-    - name: "8091"
-      port: 8091
       targetPort: 8080
   selector:
     container: app-emissary

--- a/app-emissary/deployment.yaml
+++ b/app-emissary/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-emissary-deployment
+  labels:
+    container: app-emissary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      container: app-emissary
+  template:
+    metadata:
+      labels:
+        container: app-emissary
+    spec:
+      containers:
+        - name: app-emissary
+          image: owasp/zap2docker-stable:s2021-12-16
+          command:
+            [
+              "zap.sh",
+              "-daemon",
+              "-port",
+              "8080",
+              "-host",
+              "0.0.0.0",
+              "-config",
+              "api.addrs.addr.regex=true",
+              "-config",
+              "api.addrs.addr.name=zap|localhost|127.0.0.1|172.25.0.*|appemissary_zap_(100|[1-9][0-9]?)",
+              "-config",
+              "api.key=${ZAP_API_KEY}",
+            ]
+          ports:
+            - containerPort: 80
+

--- a/app-emissary/deployment.yaml
+++ b/app-emissary/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     container: app-emissary
 spec:
-  replicas: 1
+  replicas: 10
   selector:
     matchLabels:
       container: app-emissary

--- a/app-emissary/docker-compose.yml
+++ b/app-emissary/docker-compose.yml
@@ -24,30 +24,30 @@ services:
       compose_pt-net:
     # Soft limit of 12 test sessions.
     ports:
-    - "8080-8091:8080"
+      - "8080-8091:8080"
     # Todo: KC: create new api key on every test run.
-    command: [
-      "zap.sh",
-      "-daemon",
-      "-port",
-      "8080",
-      "-host",
-      "0.0.0.0",
-      "-config",
-      "api.addrs.addr.regex=true",
-      "-config",
-      "api.addrs.addr.name=zap|localhost|127.0.0.1|172.25.0.*|appemissary_zap_(100|[1-9][0-9]?)",
-      "-config",
-      "api.key=${ZAP_API_KEY}"
-    ]
+    command:
+      [
+        "zap.sh",
+        "-daemon",
+        "-port",
+        "8080",
+        "-host",
+        "0.0.0.0",
+        "-config",
+        "api.addrs.addr.regex=true",
+        "-config",
+        "api.addrs.addr.name=zap|localhost|127.0.0.1|172.25.0.*|appemissary_zap_(100|[1-9][0-9]?)",
+        "-config",
+        "api.key=${ZAP_API_KEY}",
+      ]
     volumes:
-     - type: bind
-       # Same variables found in contOrc IAC variables.tf for cloud environment.
-       source: ${HOST_DIR_APP_SCANNER}
-       target: ${ZAP_DIR_APP_SCANNER_MOUNT_TARGET}
-    # Uncomment the bind mount to enable debug logs in Zap containers.    
+      - type: bind
+        # Same variables found in contOrc IAC variables.tf for cloud environment.
+        source: ${HOST_DIR_APP_SCANNER}
+        target: ${ZAP_DIR_APP_SCANNER_MOUNT_TARGET}
+    # Uncomment the bind mount to enable debug logs in Zap containers.
     # - type: bind
     #   # Same variables found in contOrc IAC variables.tf for cloud environment.
     #   source: ${HOST_ZAP_LOG4J_PROPERTIES_PATH}
     #   target: ${ZAP_LOG4J_PROPERTIES_PATH_MOUNT_TARGET}
-

--- a/selenium-standalone/deployment.yaml
+++ b/selenium-standalone/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: selenium-standalone-deployment
+  labels:
+    container: selenium-standalone
+  replicas: 1
+  selector:
+    matchLabels:
+      container: selenium-standalone
+  template:
+    metadata:
+      labels:
+        container: selenium-standalone
+    spec:
+      containers:
+        - name: chrome
+          image: selenium/standalone-chrome:96.0
+
+        - name: firefox
+          image: selenium/standalone-firefox:95.0
+
+
+

--- a/selenium-standalone/deployment.yaml
+++ b/selenium-standalone/deployment.yaml
@@ -63,42 +63,11 @@ metadata:
     container: selenium-standalone
   name: selenium-standalone-service
 spec:
+  type: NodePort
   ports:
     - name: "4444"
       port: 4444
-      targetPort: 4444
-    - name: "4445"
-      port: 4445
-      targetPort: 4444
-    - name: "4446"
-      port: 4446
-      targetPort: 4444
-    - name: "4447"
-      port: 4447
-      targetPort: 4444
-    - name: "4448"
-      port: 4448
-      targetPort: 4444
-    - name: "4449"
-      port: 4449
-      targetPort: 4444
-    - name: "4450"
-      port: 4450
-      targetPort: 4444
-    - name: "4451"
-      port: 4451
-      targetPort: 4444
-    - name: "4452"
-      port: 4452
-      targetPort: 4444
-    - name: "4453"
-      port: 4453
-      targetPort: 4444
-    - name: "4454"
-      port: 4454
-      targetPort: 4444
-    - name: "4455"
-      port: 4455
+      nodePort: 30001
       targetPort: 4444
   selector:
     container: selenium-standalone

--- a/selenium-standalone/deployment.yaml
+++ b/selenium-standalone/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: selenium-standalone-deployment
   labels:
     container: selenium-standalone
+spec:
   replicas: 1
   selector:
     matchLabels:
@@ -16,9 +17,64 @@ metadata:
       containers:
         - name: chrome
           image: selenium/standalone-chrome:96.0
+          matchLabels:
 
         - name: firefox
           image: selenium/standalone-firefox:95.0
-
-
-
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: chrome
+  name: chrome-service
+spec:
+  ports:
+    - name: "4444"
+      port: 4444
+      targetPort: 4444
+    - name: "4445"
+      port: 4445
+      targetPort: 4444
+    - name: "4446"
+      port: 4446
+      targetPort: 4444
+    - name: "4447"
+      port: 4447
+      targetPort: 4444
+    - name: "4448"
+      port: 4448
+      targetPort: 4444
+    - name: "4449"
+      port: 4449
+      targetPort: 4444
+    - name: "4450"
+      port: 4450
+      targetPort: 4444
+    - name: "4451"
+      port: 4451
+      targetPort: 4444
+    - name: "4452"
+      port: 4452
+      targetPort: 4444
+    - name: "4453"
+      port: 4453
+      targetPort: 4444
+    - name: "4454"
+      port: 4454
+      targetPort: 4444
+    - name: "4455"
+      port: 4455
+      targetPort: 4444
+  selector:
+    io.kompose.service: chrome
+status:
+  loadBalancer: {}

--- a/selenium-standalone/deployment.yaml
+++ b/selenium-standalone/deployment.yaml
@@ -17,9 +17,6 @@ spec:
       containers:
         - name: chrome
           image: selenium/standalone-chrome:96.0
-
-        - name: firefox
-          image: selenium/standalone-firefox:95.0
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
@@ -47,9 +44,6 @@ spec:
         container: selenium-standalone
     spec:
       containers:
-        - name: chrome
-          image: selenium/standalone-chrome:96.0
-
         - name: firefox
           image: selenium/standalone-firefox:95.0
           volumeMounts:

--- a/selenium-standalone/deployment.yaml
+++ b/selenium-standalone/deployment.yaml
@@ -34,8 +34,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    io.kompose.service: chrome
-  name: chrome-service
+    container: selenium-standalone
+  name: selenium-standalone-service
 spec:
   ports:
     - name: "4444"
@@ -75,6 +75,4 @@ spec:
       port: 4455
       targetPort: 4444
   selector:
-    io.kompose.service: chrome
-status:
-  loadBalancer: {}
+    container: selenium-standalone

--- a/selenium-standalone/deployment.yaml
+++ b/selenium-standalone/deployment.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: selenium-standalone-deployment
+  name: selenium-standalone-chrome
   labels:
     container: selenium-standalone
 spec:
-  replicas: 1
+  replicas: 10
   selector:
     matchLabels:
       container: selenium-standalone
@@ -17,7 +17,6 @@ spec:
       containers:
         - name: chrome
           image: selenium/standalone-chrome:96.0
-          matchLabels:
 
         - name: firefox
           image: selenium/standalone-firefox:95.0
@@ -29,6 +28,39 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: selenium-standalone-firefox
+  labels:
+    container: selenium-standalone
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      container: selenium-standalone
+  template:
+    metadata:
+      labels:
+        container: selenium-standalone
+    spec:
+      containers:
+        - name: chrome
+          image: selenium/standalone-chrome:96.0
+
+        - name: firefox
+          image: selenium/standalone-firefox:95.0
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
@binarymist This is still a draft at the moment for purpleteam-labs/purpleteam#107. I need to address the following things 

* Figure the right networking approach. If to have a networking config that allows using the existing dc_compose_net network, this is also the reason I haven't specified the port since they won't be accessible to other purpleteam components if they're not in the same network. I am research to see if I can expose service that uses the same network 

* The shm size on the pods needs to be increased to at least 1GB to avoid chromium issues, I still haven't found a good solution to that.
 
* And lastly, a good way to authenticate against the k8s API.  



### Checklist

* [x] I have read the contributing guidelines
* [x] I have read the documentation
* [x] I have included a descriptive Pull Request title
* [x] I have included a Pull Request description of my changes
* [ ] I have included tests where/when required (see contributing guidelines)
* [ ] I have included documentation modifications/additions where/when required (see contributing guidelines)
