### PR TITLE
Bumped docker-compose versions to 3.8

### DIFF
--- a/app-emissary/docker-compose.yml
+++ b/app-emissary/docker-compose.yml
@@ -11,7 +11,7 @@
 # Waiting to see what happens with docker-compose-ui support in order to move to 3.8
 #   https://github.com/francescou/docker-compose-ui/issues/120
 #   https://github.com/francescou/docker-compose-ui/issues/110
-version: "3.6"
+version: "3.8"
 
 networks:
   compose_pt-net:

--- a/selenium-standalone/docker-compose.yml
+++ b/selenium-standalone/docker-compose.yml
@@ -10,7 +10,7 @@
 # Waiting to see what happens with docker-compose-ui support in order to move to 3.8
 #   https://github.com/francescou/docker-compose-ui/issues/120
 #   https://github.com/francescou/docker-compose-ui/issues/110
-version: "3.6"
+version: "3.8"
 
 networks:
   compose_pt-net:


### PR DESCRIPTION
Hey,

I have bumped docker-compose version to 3.8, and tested it to be working fine on my local environment.

This is a proof-of-work submission for GSoC'23 contributions. I would like to continue contributing to this project further till its conclusion. I have the required knowledge (Kubernetes, JavaScript, Linux, Docker, Python, etc.) for the same. I request you to please guide me further so I can focus in the appropriate direction. 

Regards,
Prashant
